### PR TITLE
corrected bit mask for setting oversample of PressureSensor

### DIFF
--- a/src/Zanshin_BME680.cpp
+++ b/src/Zanshin_BME680.cpp
@@ -262,7 +262,7 @@ bool BME680_Class::setOversampling(const uint8_t sensor, const uint8_t sampling)
     } // of HumiditySensor
     case PressureSensor : 
     {
-      tempRegister = readByte(BME680_CONTROL_MEASURE_REGISTER) & B11000111; // Get contents, mask unused bits
+      tempRegister = readByte(BME680_CONTROL_MEASURE_REGISTER) & B11100011; // Get contents, mask unused bits
       putData(BME680_CONTROL_MEASURE_REGISTER,(uint8_t)(tempRegister|(sampling<<2))); // Update pressure bits
       break;
     } // of PressureSensor


### PR DESCRIPTION
According to BME680 data sheet the bits osrs_p are located on bit4..2 within the BME680_CONTROL_MEASURE_REGISTER. It looked like there was a small typo within the code which is now corrected.

.... the change is too small for a thorough pull request template :)

# Description
Please include a text summary of the change and which issue(s) is/are fixed or addressed. Should the change have any dependencies 
then these should be listed here.

Fixes # (issue)
In order to make tracking easier and to properly document the process,
pull requests should always refer to an active issue in the list - be it a bug fix or an enhancement or some other type of issue.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Arduino version:
* Arduino Hardware:
* SDK: (Arduino IDE, Atmel Studio, etc.)

# Checklist:

- [ ] The changes made link back to an existing issue number
- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation / Wiki Page(s)
- [ ] My changes generate no new warnings
- [ ] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

![Zanshin Logo](https://www.sv-zanshin.com/r/images/site/gif/zanshinkanjitiny.gif) <img src="https://www.sv-zanshin.com/r/images/site/gif/zanshintext.gif" width="75"/>
